### PR TITLE
Add branching detour to 3D maze

### DIFF
--- a/3dmaze.py
+++ b/3dmaze.py
@@ -4,6 +4,7 @@ from typing import List, Set, Tuple, Dict
 import streamlit as st
 from PIL import Image, ImageDraw
 from math import atan2, cos, sin, pi
+from multi_maze import generate_multi_maze
 
 Cell = Tuple[int, int]
 
@@ -75,7 +76,7 @@ def _generate_level(width: int, height: int) -> List[List[int]]:
 
 
 def generate_maze(
-    width: int, height: int, levels: int, max_wind_pairs: int = 3
+    width: int, height: int, levels: int
 ) -> Tuple[
     List[List[List[int]]],
     List[Set[Cell]],
@@ -84,64 +85,131 @@ def generate_maze(
     Cell,
     Cell,
 ]:
-    """Generate a 3D maze allowing multiple elevator pairs per level."""
+    """Generate a 3D maze with a detour that revisits an upper floor."""
 
-    grids = [_generate_level(width, height) for _ in range(levels)]
-    up = [set() for _ in range(levels)]
-    down = [set() for _ in range(levels)]
+    # fallback to simple behaviour for small mazes
+    if levels < 5:
+        grids = [_generate_level(width, height) for _ in range(levels)]
+        up = [set() for _ in range(levels)]
+        down = [set() for _ in range(levels)]
+        path: List[Tuple[int, int, int]] = []
+        sx, sy = random.randrange(width), random.randrange(height)
+        start = (levels - 1, sx, sy)
+        path.append(start)
+        x, y = sx, sy
+        for level in range(levels - 1, 0, -1):
+            nx, ny = random.randrange(width), random.randrange(height)
+            segment = _find_path(grids[level], (x, y), (nx, ny))
+            for cx, cy in segment[1:]:
+                path.append((level, cx, cy))
+            down[level].add((nx, ny))
+            up[level - 1].add((nx, ny))
+            x, y = nx, ny
+            path.append((level - 1, x, y))
+        fx, fy = width // 2, height - 1
+        segment = _find_path(grids[0], (x, y), (fx, fy))
+        for cx, cy in segment[1:]:
+            path.append((0, cx, cy))
+        finish = (0, fx, fy)
+        path.append(finish)
+        return grids, up, down, path, start, finish
 
+    branch_level = levels - 4
+
+    grids: List[List[List[int]]] = []
+    branch_info = None
+    for lvl in range(levels):
+        if lvl == branch_level:
+            grid, starts, finishes, solutions = generate_multi_maze(width, height, 2)
+            grids.append(grid)
+            branch_info = (starts, finishes, solutions)
+        else:
+            grids.append(_generate_level(width, height))
+
+    up: List[Set[Cell]] = [set() for _ in range(levels)]
+    down: List[Set[Cell]] = [set() for _ in range(levels)]
     path: List[Tuple[int, int, int]] = []
 
-    # starting cell on the top level
     sx, sy = random.randrange(width), random.randrange(height)
     start = (levels - 1, sx, sy)
     path.append(start)
-
     x, y = sx, sy
     level = levels - 1
-    visits = [0] * levels
-    visits[level] = 1
-    up_moves = 0
 
-    while level > 0:
-        # pick a random destination cell on this level
+    # descend until reaching the floor above the branching level
+    while level > branch_level + 1:
         nx, ny = random.randrange(width), random.randrange(height)
-        while (nx, ny) == (x, y):
-            nx, ny = random.randrange(width), random.randrange(height)
         segment = _find_path(grids[level], (x, y), (nx, ny))
         for cx, cy in segment[1:]:
             path.append((level, cx, cy))
-
-        # decide direction of the elevator
-        direction = -1
-        if (
-            level < levels - 1
-            and visits[level] < max_wind_pairs
-            and random.random() < 0.3
-            and up_moves < 3
-        ):
-            direction = 1
-            up_moves += 1
-
-        next_level = level + direction
-        if direction == -1:
-            down[level].add((nx, ny))
-            up[next_level].add((nx, ny))
-        else:
-            up[level].add((nx, ny))
-            down[next_level].add((nx, ny))
-
+        down[level].add((nx, ny))
+        up[level - 1].add((nx, ny))
         x, y = nx, ny
-        level = next_level
-        visits[level] += 1
+        level -= 1
         path.append((level, x, y))
 
-    # final segment on bottom level leading to the exit
+    if branch_info:
+        starts, finishes, solutions = branch_info
+        a_start, a_finish = starts[0], finishes[0]
+        b_start, b_finish = starts[1], finishes[1]
+        path_a, path_b = solutions[0], solutions[1]
+
+        # connect to first maze on branching floor
+        segment = _find_path(grids[level], (x, y), a_start)
+        for cx, cy in segment[1:]:
+            path.append((level, cx, cy))
+        down[level].add(a_start)
+        up[level - 1].add(a_start)
+        x, y = a_start
+        level -= 1
+        path.append((level, x, y))
+
+        # traverse first maze
+        for cx, cy in path_a[1:]:
+            path.append((level, cx, cy))
+
+        down[level].add(a_finish)
+        up[level - 1].add(a_finish)
+        x, y = a_finish
+        level -= 1
+        path.append((level, x, y))
+
+        # move on lower floor to entrance of second maze
+        segment = _find_path(grids[level], (x, y), b_start)
+        for cx, cy in segment[1:]:
+            path.append((level, cx, cy))
+        up[level].add(b_start)
+        down[level + 1].add(b_start)
+        x, y = b_start
+        level += 1
+        path.append((level, x, y))
+
+        # traverse second maze
+        for cx, cy in path_b[1:]:
+            path.append((level, cx, cy))
+
+        down[level].add(b_finish)
+        up[level - 1].add(b_finish)
+        x, y = b_finish
+        level -= 1
+        path.append((level, x, y))
+
+    # continue descending to the bottom
+    while level > 0:
+        nx, ny = random.randrange(width), random.randrange(height)
+        segment = _find_path(grids[level], (x, y), (nx, ny))
+        for cx, cy in segment[1:]:
+            path.append((level, cx, cy))
+        down[level].add((nx, ny))
+        up[level - 1].add((nx, ny))
+        x, y = nx, ny
+        level -= 1
+        path.append((level, x, y))
+
     fx, fy = width // 2, height - 1
     segment = _find_path(grids[0], (x, y), (fx, fy))
     for cx, cy in segment[1:]:
         path.append((0, cx, cy))
-
     finish = (0, fx, fy)
     path.append(finish)
 
@@ -244,13 +312,10 @@ def main() -> None:
         w = st.number_input("width", 5, 40, 20)
         h = st.number_input("height", 5, 40, 20)
         z = st.number_input("levels", 10, 100, 20)
-        max_pairs = st.number_input("max wind pairs", 1, 10, 3)
         generate = st.button("Generate")
 
     if generate or "maze" not in st.session_state:
-        grids, up, down, path, start, finish = generate_maze(
-            int(w), int(h), int(z), int(max_pairs)
-        )
+        grids, up, down, path, start, finish = generate_maze(int(w), int(h), int(z))
         st.session_state["maze"] = (grids, up, down, path, start, finish)
         st.session_state["level"] = z-1
         st.session_state["show"] = False

--- a/kontur-maze-backup.py
+++ b/kontur-maze-backup.py
@@ -61,13 +61,31 @@ def _point_in_polygon(x: float, y: float, poly: List[Tuple[float, float]]) -> bo
     return inside
 
 
+def _rotate_poly(poly: np.ndarray, times: int) -> np.ndarray:
+    """Rotate polygon by 90-degree increments around its bounding box."""
+    times %= 4
+    if times == 0:
+        return poly
+    w = poly[:, 0].max()
+    h = poly[:, 1].max()
+    if times == 1:
+        return np.column_stack((h - poly[:, 1], poly[:, 0]))
+    if times == 2:
+        return np.column_stack((w - poly[:, 0], h - poly[:, 1]))
+    return np.column_stack((poly[:, 1], w - poly[:, 0]))
+
+
 def _masks_from_polygon(
     width: int, height: int, poly: np.ndarray
 ) -> Tuple[np.ndarray, np.ndarray]:
     grid_poly: List[Tuple[float, float]] = []
+    sx = 0.98 * width / poly[:, 0].max()
+    sy = 0.98 * height / poly[:, 1].max()
+    ox = (width - poly[:, 0].max() * sx) / 2
+    oy = (height - poly[:, 1].max() * sy) / 2
     for x, y in poly:
-        gx = x / poly[:, 0].max() * width
-        gy = y / poly[:, 1].max() * height
+        gx = x * sx + ox
+        gy = y * sy + oy
         grid_poly.append((gx, gy))
     center_mask = np.zeros((height, width), dtype=bool)
     full_mask = np.zeros((height, width), dtype=bool)
@@ -179,8 +197,13 @@ def generate_contour_maze(
     scale: float,
     start: Tuple[int, int],
     end: Tuple[int, int],
+    poly: np.ndarray | None = None,
+    rotation: int = 0,
 ):
-    poly = _extract_polygon(img, detail, smooth)
+    if poly is None:
+        poly = _extract_polygon(img, detail, smooth)
+    if rotation:
+        poly = _rotate_poly(poly, rotation)
     mask, full_mask = _masks_from_polygon(width, height, poly)
     if not mask[start] or not mask[end]:
         raise ValueError("Start lub meta poza konturem")
@@ -190,9 +213,11 @@ def generate_contour_maze(
     cell_size = min(w_img / width, h_img / height)
     w_svg = width * cell_size * scale
     h_svg = height * cell_size * scale
-    scale_x = w_svg / w_img
-    scale_y = h_svg / h_img
-    poly_svg = [(x * scale_x, y * scale_y) for x, y in poly]
+    scale_x = 0.98 * w_svg / w_img
+    scale_y = 0.98 * h_svg / h_img
+    off_x = (w_svg - w_img * scale_x) / 2
+    off_y = (h_svg - h_img * scale_y) / 2
+    poly_svg = [(x * scale_x + off_x, y * scale_y + off_y) for x, y in poly]
     svg = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{w_svg}" height="{h_svg}" viewBox="0 0 {w_svg} {h_svg}">'
     ]
@@ -304,6 +329,29 @@ def generate_contour_maze(
     return base_svg, solution_lines, w_svg, h_svg
 
 
+def _build_outline(width, height, scale, base_poly, rotation, img):
+    rot_poly = _rotate_poly(base_poly, rotation)
+    mask, full_mask = _masks_from_polygon(width, height, rot_poly)
+    w_img, h_img = rot_poly[:, 0].max(), rot_poly[:, 1].max()
+    cell_size = min(w_img / width, h_img / height)
+    w_svg = width * cell_size * scale
+    h_svg = height * cell_size * scale
+    sx = 0.98 * w_svg / w_img
+    sy = 0.98 * h_svg / h_img
+    ox = (w_svg - w_img * sx) / 2
+    oy = (h_svg - h_img * sy) / 2
+    poly_svg = [(x * sx + ox, y * sy + oy) for x, y in rot_poly]
+    st.session_state["outline"] = (
+        poly_svg,
+        mask,
+        full_mask,
+        cell_size,
+        w_svg,
+        h_svg,
+        img,
+    )
+
+
 def main() -> None:
     st.title("Kontur Maze")
     uploaded = st.file_uploader("Wczytaj obraz", type=["png", "jpg", "jpeg"])
@@ -319,24 +367,10 @@ def main() -> None:
     if uploaded:
         img = Image.open(uploaded)
         if start_btn or "outline" not in st.session_state:
-            poly = _extract_polygon(img, detail, smooth)
-            mask, full_mask = _masks_from_polygon(width, height, poly)
-            w_img, h_img = poly[:, 0].max(), poly[:, 1].max()
-            cell_size = min(w_img / width, h_img / height)
-            w_svg = width * cell_size * scale
-            h_svg = height * cell_size * scale
-            scale_x = w_svg / w_img
-            scale_y = h_svg / h_img
-            poly_svg = [(x * scale_x, y * scale_y) for x, y in poly]
-            st.session_state["outline"] = (
-                poly_svg,
-                mask,
-                full_mask,
-                cell_size,
-                w_svg,
-                h_svg,
-                img,
-            )
+            base_poly = _extract_polygon(img, detail, smooth)
+            st.session_state["base_poly"] = base_poly
+            st.session_state["rotation"] = 0
+            _build_outline(width, height, scale, base_poly, 0, img)
             st.session_state["start_input"] = ""
             st.session_state["end_input"] = ""
             st.session_state.pop("maze_svg", None)
@@ -356,9 +390,21 @@ def main() -> None:
             ) = st.session_state["outline"]
 
             if st.session_state.get("maze_svg") is None:
-                target = st.radio(
-                    "Wpisz kliknięcie do", ["Start", "Meta"], key="target_field", horizontal=True
-                )
+                if st.button("obróć"):
+                    st.session_state["rotation"] = (st.session_state.get("rotation", 0) + 1) % 4
+                    _build_outline(
+                        width,
+                        height,
+                        scale,
+                        st.session_state["base_poly"],
+                        st.session_state["rotation"],
+                        img,
+                    )
+                    st.session_state["start_input"] = ""
+                    st.session_state["end_input"] = ""
+                    st.session_state.pop("start", None)
+                    st.session_state.pop("end", None)
+                    st.rerun()
                 start_str = st.text_input("Start", key="start_input")
                 end_str = st.text_input("Meta", key="end_input")
                 st.text_input("clicked", key="clicked_cell", label_visibility="collapsed")
@@ -406,15 +452,19 @@ def main() -> None:
                 if clicked:
                     try:
                         r, c = map(int, clicked.split(','))
-                        if st.session_state.get("target_field") == "Start":
-                            st.session_state["start_input"] = f"{r},{c}"
-                        else:
-                            st.session_state["end_input"] = f"{r},{c}"
+                        pos = f"{r},{c}"
+                        if not st.session_state.get("start_input"):
+                            st.session_state["start_input"] = pos
+                        elif (
+                            not st.session_state.get("end_input")
+                            and pos != st.session_state["start_input"]
+                        ):
+                            st.session_state["end_input"] = pos
                     except Exception:
                         pass
                     finally:
                         st.session_state["clicked_cell"] = ""
-                    st.experimental_rerun()
+                        st.rerun()
 
                 if st.button("Generuj"):
                     start_val = st.session_state.get("start_input", "")
@@ -437,6 +487,10 @@ def main() -> None:
                                 scale,
                                 (sr, sc),
                                 (er, ec),
+                                poly=_rotate_poly(
+                                    st.session_state["base_poly"],
+                                    st.session_state.get("rotation", 0),
+                                ),
                             )
                         except Exception as e:
                             st.error(str(e))
@@ -448,12 +502,42 @@ def main() -> None:
                             st.session_state["start"] = (sr, sc)
                             st.session_state["end"] = (er, ec)
                             st.session_state["show_solution"] = False
-                            st.experimental_rerun()
+                            st.rerun()
             if st.session_state.get("maze_svg"):
-                if st.button("rozwiązanie"):
-                    st.session_state["show_solution"] = not st.session_state.get(
-                        "show_solution", False
-                    )
+                col1, col2 = st.columns(2)
+                with col1:
+                    if st.button("rozwiązanie"):
+                        st.session_state["show_solution"] = not st.session_state.get(
+                            "show_solution", False
+                        )
+                with col2:
+                    if st.button("generuj ponownie"):
+                        try:
+                            maze_svg, sol_svg, w_svg, h_svg = generate_contour_maze(
+                                img,
+                                width,
+                                height,
+                                contour_pt,
+                                maze_pt,
+                                detail,
+                                smooth,
+                                scale,
+                                st.session_state["start"],
+                                st.session_state["end"],
+                                poly=_rotate_poly(
+                                    st.session_state["base_poly"],
+                                    st.session_state.get("rotation", 0),
+                                ),
+                            )
+                        except Exception as e:
+                            st.error(str(e))
+                        else:
+                            st.session_state["maze_svg"] = maze_svg
+                            st.session_state["solution_svg"] = sol_svg
+                            st.session_state["w_svg"] = w_svg
+                            st.session_state["h_svg"] = h_svg
+                            st.session_state["show_solution"] = False
+                            st.rerun()
                 svg = st.session_state["maze_svg"]
                 if st.session_state.get("show_solution") and st.session_state.get(
                     "solution_svg"

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -1,12 +1,28 @@
 import random
 from typing import List, Tuple
 from collections import deque
+import subprocess
+import sys
 
 import numpy as np
 import streamlit as st
 from PIL import Image, ImageFilter
 
-from skimage import measure
+try:
+    from skimage import measure
+except ModuleNotFoundError:  # pragma: no cover - fallback install
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--no-cache-dir",
+            "scikit-image",
+        ]
+    )
+    from skimage import measure
 
 Cell = Tuple[int, int]
 

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -5,6 +5,7 @@ from typing import List, Tuple
 import numpy as np
 from PIL import Image
 import streamlit as st
+import streamlit.components.v1 as components
 
 try:  # pragma: no cover - runtime dependency check
     from skimage import measure
@@ -373,8 +374,8 @@ def main() -> None:
                 + "</svg>"
                 + script
             )
-            selection = st.components.v1.html(html, height=int(h_svg) + 10)
-            if selection:
+            selection = components.html(html, height=int(h_svg) + 10)
+            if isinstance(selection, str) and selection:
                 r, c = map(int, selection.split(","))
                 if st.session_state.get("start") is None:
                     st.session_state["start"] = (r, c)

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -1,24 +1,40 @@
 import random
 from typing import List, Tuple
+from collections import deque
 
+import numpy as np
 import streamlit as st
 from PIL import Image, ImageFilter
+import svgwrite
+from skimage import measure
 
 Cell = Tuple[int, int]
 
 
-def _carve_maze(w: int, h: int) -> List[List[int]]:
-    """Generate a rectangular maze using depth-first search."""
+def _carve_maze_mask(allowed: np.ndarray) -> Tuple[List[List[int]], Cell]:
+    """Carve a maze confined to the allowed mask."""
+    h, w = allowed.shape
     grid = [[1] * (w * 2 + 1) for _ in range(h * 2 + 1)]
-    stack = [(0, 0)]
-    visited = {(0, 0)}
+    start: Cell = (0, 0)
+    found = False
+    for y in range(h):
+        for x in range(w):
+            if allowed[y, x]:
+                start = (x, y)
+                found = True
+                break
+        if found:
+            break
+    stack = [start]
+    visited = {start}
+    dirs = [(-1, 0), (1, 0), (0, -1), (0, 1)]
     while stack:
         x, y = stack[-1]
         grid[y * 2 + 1][x * 2 + 1] = 0
         neighbors = []
-        for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+        for dx, dy in dirs:
             nx, ny = x + dx, y + dy
-            if 0 <= nx < w and 0 <= ny < h and (nx, ny) not in visited:
+            if 0 <= nx < w and 0 <= ny < h and allowed[ny, nx] and (nx, ny) not in visited:
                 neighbors.append((nx, ny, dx, dy))
         if neighbors:
             nx, ny, dx, dy = random.choice(neighbors)
@@ -27,62 +43,166 @@ def _carve_maze(w: int, h: int) -> List[List[int]]:
             stack.append((nx, ny))
         else:
             stack.pop()
-    return grid
+    return grid, start
 
 
-def _grid_to_image(grid: List[List[int]]) -> Image.Image:
-    """Convert grid representation into a PIL image."""
-    h = len(grid)
-    w = len(grid[0])
-    img = Image.new("1", (w, h), 1)
-    px = img.load()
-    for y, row in enumerate(grid):
-        for x, val in enumerate(row):
-            if val == 1:
-                px[x, y] = 0
-    return img
+def _solve_maze(grid: List[List[int]], start: Cell, allowed: np.ndarray) -> Tuple[Cell, List[Cell]]:
+    """Find farthest reachable cell and path from start."""
+    w = allowed.shape[1]
+    h = allowed.shape[0]
+    dirs = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+    dist = {start: 0}
+    queue = deque([start])
+    while queue:
+        x, y = queue.popleft()
+        for dx, dy in dirs:
+            nx, ny = x + dx, y + dy
+            if (
+                0 <= nx < w
+                and 0 <= ny < h
+                and allowed[ny, nx]
+                and grid[y * 2 + 1 + dy][x * 2 + 1 + dx] == 0
+                and (nx, ny) not in dist
+            ):
+                dist[(nx, ny)] = dist[(x, y)] + 1
+                queue.append((nx, ny))
+    end = max(dist, key=dist.get)
+    path = [end]
+    while path[-1] != start:
+        x, y = path[-1]
+        for dx, dy in dirs:
+            nx, ny = x + dx, y + dy
+            if (
+                (nx, ny) in dist
+                and dist[(nx, ny)] == dist[(x, y)] - 1
+                and grid[y * 2 + 1 + dy][x * 2 + 1 + dx] == 0
+            ):
+                path.append((nx, ny))
+                break
+    path.reverse()
+    return end, path
 
 
-def generate_contour_maze(src: Image.Image, w: int, h: int, scale: int, thickness: int) -> Image.Image:
-    """Draw the outline of ``src`` and generate a maze inside it."""
-    grid = _carve_maze(w, h)
-    maze_img = _grid_to_image(grid)
+def generate_contour_maze(
+    src: Image.Image,
+    w: int,
+    h: int,
+    scale: int,
+    contour_pt: float,
+    maze_pt: float,
+    show_solution: bool,
+) -> Tuple[str, int, int]:
+    """Generate maze inside image contour and return SVG string."""
+    allowed = np.array(src.convert("L").resize((w, h), Image.LANCZOS)) < 128
+    grid, start = _carve_maze_mask(allowed)
+    end, solution = _solve_maze(grid, start, allowed)
 
-    mask = src.convert("L").resize(maze_img.size)
-    mask = mask.point(lambda p: 255 if p < 128 else 0, mode="1")
+    width_px = w * scale
+    height_px = h * scale
+    mask_svg = (
+        src.convert("L")
+        .resize((width_px, height_px), Image.LANCZOS)
+        .filter(ImageFilter.GaussianBlur(1))
+    )
+    mask_np = np.array(mask_svg) < 128
+    contours = measure.find_contours(mask_np.astype(float), 0.5)
+    contour = max(contours, key=len) if contours else []
 
-    edge = mask.filter(ImageFilter.FIND_EDGES)
-    size = max(1, int(thickness))
-    if size % 2 == 0:
-        size += 1
-    edge = edge.filter(ImageFilter.MaxFilter(size)).convert("1")
+    dwg = svgwrite.Drawing(size=(width_px, height_px))
+    if len(contour):
+        path = svgwrite.path.Path(
+            stroke="black", fill="none", stroke_width=f"{contour_pt}pt"
+        )
+        pts = [(p[1], p[0]) for p in contour]
+        path.push("M", pts[0][0], pts[0][1])
+        for x, y in pts[1:]:
+            path.push("L", x, y)
+        path.push("Z")
+        dwg.add(path)
 
-    base = Image.new("1", maze_img.size, 1)
-    base.paste(maze_img, mask=mask)
-    base.paste(0, mask=edge)
+    cell = scale
+    for y in range(h):
+        for x in range(w):
+            if not allowed[y, x]:
+                continue
+            if x + 1 < w and allowed[y, x + 1] and grid[y * 2 + 1][x * 2 + 2] == 1:
+                x1 = (x + 1) * cell
+                y1 = y * cell
+                y2 = (y + 1) * cell
+                dwg.add(
+                    dwg.line(
+                        start=(x1, y1),
+                        end=(x1, y2),
+                        stroke="black",
+                        stroke_width=f"{maze_pt}pt",
+                    )
+                )
+            if y + 1 < h and allowed[y + 1, x] and grid[y * 2 + 2][x * 2 + 1] == 1:
+                y1 = (y + 1) * cell
+                x1 = x * cell
+                x2 = (x + 1) * cell
+                dwg.add(
+                    dwg.line(
+                        start=(x1, y1),
+                        end=(x2, y1),
+                        stroke="black",
+                        stroke_width=f"{maze_pt}pt",
+                    )
+                )
 
-    if scale > 1:
-        base = base.resize((base.width * scale, base.height * scale), Image.NEAREST)
-    return base
+    def center(c: Cell) -> Tuple[float, float]:
+        cx, cy = c
+        return (cx + 0.5) * cell, (cy + 0.5) * cell
+
+    dwg.add(dwg.circle(center=center(start), r=cell * 0.2, fill="green"))
+    dwg.add(dwg.circle(center=center(end), r=cell * 0.2, fill="red"))
+
+    if show_solution:
+        pts = [center(p) for p in solution]
+        dwg.add(
+            dwg.polyline(
+                points=pts, stroke="blue", fill="none", stroke_width=f"{maze_pt}pt"
+            )
+        )
+
+    return dwg.tostring(), width_px, height_px
 
 
 def main() -> None:
     st.title("kontur maze")
     uploaded = st.file_uploader("Upload image", type=["png", "jpg", "jpeg"])
+    if "kontur_show_solution" not in st.session_state:
+        st.session_state["kontur_show_solution"] = False
     with st.sidebar:
         w = st.number_input("width", 5, 100, 20)
         h = st.number_input("height", 5, 100, 20)
         scale = st.number_input("scale", 1, 50, 10)
-        thick = st.number_input("contour thickness", 1, 20, 3)
+        contour_thick = st.number_input("grubość konturu (pt)", 0.1, 20.0, 3.0)
+        maze_thick = st.number_input("grubość labiryntu (pt)", 0.1, 10.0, 1.0)
         generate = st.button("Generate")
+        if st.button("rozwiązanie"):
+            st.session_state["kontur_show_solution"] = not st.session_state[
+                "kontur_show_solution"
+            ]
+    show_solution = st.session_state["kontur_show_solution"]
     if generate:
         if uploaded is None:
             st.warning("Please upload an image.")
         else:
             src = Image.open(uploaded)
-            img = generate_contour_maze(src, int(w), int(h), int(scale), int(thick))
-            st.image(img)
+            svg, w_px, h_px = generate_contour_maze(
+                src,
+                int(w),
+                int(h),
+                int(scale),
+                float(contour_thick),
+                float(maze_thick),
+                show_solution,
+            )
+            st.components.v1.html(svg, height=h_px + 10)
+            st.download_button("Download SVG", svg, file_name="maze.svg")
 
 
 if __name__ == "__main__":
     main()
+

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -381,7 +381,7 @@ def main() -> None:
                     + "</svg>"
                     + script
                 )
-                selection = components.html(html, height=int(h_svg) + 10, key="grid")
+                selection = components.html(html, height=int(h_svg) + 10)
                 if isinstance(selection, str) and selection:
                     r, c = map(int, selection.split(","))
                     if st.session_state.get("start") is None:

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -354,7 +354,7 @@ def main() -> None:
             ) = st.session_state["outline"]
 
             if st.session_state.get("maze_svg") is None:
-                clicked = st.text_input("Kliknięta kratka", key="clicked_cell")
+                st.text_input("Kliknięta kratka", key="clicked_cell")
                 rects: List[str] = []
                 for r in range(height):
                     for c in range(width):
@@ -385,6 +385,7 @@ def main() -> None:
                     + script
                 )
                 components.html(html, height=int(h_svg) + 10)
+                clicked = st.session_state.get("clicked_cell")
                 if clicked:
                     try:
                         r, c = map(int, clicked.split(","))

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -381,7 +381,7 @@ def main() -> None:
                     + "</svg>"
                     + script
                 )
-                selection = components.html(html, height=int(h_svg) + 10)
+                selection = components.html(html, height=int(h_svg) + 10, key="grid")
                 if isinstance(selection, str) and selection:
                     r, c = map(int, selection.split(","))
                     if st.session_state.get("start") is None:

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -386,21 +386,24 @@ def main() -> None:
                 )
                 components.html(html, height=int(h_svg) + 10)
                 clicked = st.session_state.get("clicked_cell")
+                rerun = False
                 if clicked:
                     try:
                         r, c = map(int, clicked.split(","))
                         if st.session_state.get("start") is None:
                             st.session_state["start"] = (r, c)
-                            st.session_state["clicked_cell"] = ""
-                            st.experimental_rerun()
+                            rerun = True
                         elif st.session_state.get("end") is None and (r, c) != st.session_state.get(
                             "start"
                         ):
                             st.session_state["end"] = (r, c)
-                            st.session_state["clicked_cell"] = ""
-                            st.experimental_rerun()
+                            rerun = True
                     except Exception:
                         pass
+                    finally:
+                        st.session_state["clicked_cell"] = ""
+                if rerun:
+                    st.experimental_rerun()
                 st.write("Start:", st.session_state.get("start"))
                 st.write("End:", st.session_state.get("end"))
 
@@ -409,24 +412,23 @@ def main() -> None:
                 and st.session_state.get("end") is not None
                 and st.session_state.get("maze_svg") is None
             ):
-                if st.button("generuj"):
-                    maze_svg, sol_svg, w_svg, h_svg = generate_contour_maze(
-                        img,
-                        width,
-                        height,
-                        contour_pt,
-                        maze_pt,
-                        detail,
-                        smooth,
-                        scale,
-                        st.session_state["start"],
-                        st.session_state["end"],
-                    )
-                    st.session_state["maze_svg"] = maze_svg
-                    st.session_state["solution_svg"] = sol_svg
-                    st.session_state["w_svg"] = w_svg
-                    st.session_state["h_svg"] = h_svg
-                    st.experimental_rerun()
+                maze_svg, sol_svg, w_svg, h_svg = generate_contour_maze(
+                    img,
+                    width,
+                    height,
+                    contour_pt,
+                    maze_pt,
+                    detail,
+                    smooth,
+                    scale,
+                    st.session_state["start"],
+                    st.session_state["end"],
+                )
+                st.session_state["maze_svg"] = maze_svg
+                st.session_state["solution_svg"] = sol_svg
+                st.session_state["w_svg"] = w_svg
+                st.session_state["h_svg"] = h_svg
+                st.experimental_rerun()
 
             if st.session_state.get("maze_svg"):
                 if st.button("rozwiązanie"):

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -1,8 +1,6 @@
 import random
 from typing import List, Tuple
 from collections import deque
-import subprocess
-import sys
 
 import numpy as np
 import streamlit as st
@@ -10,19 +8,11 @@ from PIL import Image, ImageFilter
 
 try:
     from skimage import measure
-except ModuleNotFoundError:  # pragma: no cover - fallback install
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--quiet",
-            "--no-cache-dir",
-            "scikit-image",
-        ]
-    )
-    from skimage import measure
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "scikit-image is required to compute image contours. "
+        "Please add it to your environment's dependencies."
+    ) from exc
 
 Cell = Tuple[int, int]
 

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -1,0 +1,88 @@
+import random
+from typing import List, Tuple
+
+import streamlit as st
+from PIL import Image, ImageFilter
+
+Cell = Tuple[int, int]
+
+
+def _carve_maze(w: int, h: int) -> List[List[int]]:
+    """Generate a rectangular maze using depth-first search."""
+    grid = [[1] * (w * 2 + 1) for _ in range(h * 2 + 1)]
+    stack = [(0, 0)]
+    visited = {(0, 0)}
+    while stack:
+        x, y = stack[-1]
+        grid[y * 2 + 1][x * 2 + 1] = 0
+        neighbors = []
+        for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < w and 0 <= ny < h and (nx, ny) not in visited:
+                neighbors.append((nx, ny, dx, dy))
+        if neighbors:
+            nx, ny, dx, dy = random.choice(neighbors)
+            grid[y * 2 + 1 + dy][x * 2 + 1 + dx] = 0
+            visited.add((nx, ny))
+            stack.append((nx, ny))
+        else:
+            stack.pop()
+    return grid
+
+
+def _grid_to_image(grid: List[List[int]]) -> Image.Image:
+    """Convert grid representation into a PIL image."""
+    h = len(grid)
+    w = len(grid[0])
+    img = Image.new("1", (w, h), 1)
+    px = img.load()
+    for y, row in enumerate(grid):
+        for x, val in enumerate(row):
+            if val == 1:
+                px[x, y] = 0
+    return img
+
+
+def generate_contour_maze(src: Image.Image, w: int, h: int, scale: int, thickness: int) -> Image.Image:
+    """Draw the outline of ``src`` and generate a maze inside it."""
+    grid = _carve_maze(w, h)
+    maze_img = _grid_to_image(grid)
+
+    mask = src.convert("L").resize(maze_img.size)
+    mask = mask.point(lambda p: 255 if p < 128 else 0, mode="1")
+
+    edge = mask.filter(ImageFilter.FIND_EDGES)
+    size = max(1, int(thickness))
+    if size % 2 == 0:
+        size += 1
+    edge = edge.filter(ImageFilter.MaxFilter(size)).convert("1")
+
+    base = Image.new("1", maze_img.size, 1)
+    base.paste(maze_img, mask=mask)
+    base.paste(0, mask=edge)
+
+    if scale > 1:
+        base = base.resize((base.width * scale, base.height * scale), Image.NEAREST)
+    return base
+
+
+def main() -> None:
+    st.title("kontur maze")
+    uploaded = st.file_uploader("Upload image", type=["png", "jpg", "jpeg"])
+    with st.sidebar:
+        w = st.number_input("width", 5, 100, 20)
+        h = st.number_input("height", 5, 100, 20)
+        scale = st.number_input("scale", 1, 50, 10)
+        thick = st.number_input("contour thickness", 1, 20, 3)
+        generate = st.button("Generate")
+    if generate:
+        if uploaded is None:
+            st.warning("Please upload an image.")
+        else:
+            src = Image.open(uploaded)
+            img = generate_contour_maze(src, int(w), int(h), int(scale), int(thick))
+            st.image(img)
+
+
+if __name__ == "__main__":
+    main()

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -6,10 +6,19 @@ import numpy as np
 from PIL import Image
 import streamlit as st
 
-try:
+try:  # pragma: no cover - runtime dependency check
     from skimage import measure
-except Exception as e:  # pragma: no cover - informative message
-    raise RuntimeError("scikit-image is required for contour extraction") from e
+except Exception:
+    import sys
+    import subprocess
+    import tempfile
+
+    tmp = tempfile.mkdtemp()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--no-cache-dir", "--target", tmp, "scikit-image"]
+    )
+    sys.path.append(tmp)
+    from skimage import measure
 
 
 def _point_in_polygon(x: float, y: float, poly: List[Tuple[float, float]]) -> bool:

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -5,7 +5,15 @@ from collections import deque
 import numpy as np
 import streamlit as st
 from PIL import Image, ImageFilter
-import svgwrite
+
+try:  # ensure svgwrite is available at runtime
+    import svgwrite
+except ImportError:  # pragma: no cover - best effort install
+    import subprocess, sys
+
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "svgwrite"])  # type: ignore[no-untyped-call]
+    import svgwrite
+
 from skimage import measure
 
 Cell = Tuple[int, int]

--- a/kontur-maze.py
+++ b/kontur-maze.py
@@ -356,9 +356,6 @@ def main() -> None:
             ) = st.session_state["outline"]
 
             if st.session_state.get("maze_svg") is None:
-                target = st.radio(
-                    "Wpisz kliknięcie do", ["Start", "Meta"], key="target_field", horizontal=True
-                )
                 start_str = st.text_input("Start", key="start_input")
                 end_str = st.text_input("Meta", key="end_input")
                 st.text_input("clicked", key="clicked_cell", label_visibility="collapsed")
@@ -406,15 +403,19 @@ def main() -> None:
                 if clicked:
                     try:
                         r, c = map(int, clicked.split(','))
-                        if st.session_state.get("target_field") == "Start":
-                            st.session_state["start_input"] = f"{r},{c}"
-                        else:
-                            st.session_state["end_input"] = f"{r},{c}"
+                        pos = f"{r},{c}"
+                        if not st.session_state.get("start_input"):
+                            st.session_state["start_input"] = pos
+                        elif (
+                            not st.session_state.get("end_input")
+                            and pos != st.session_state["start_input"]
+                        ):
+                            st.session_state["end_input"] = pos
                     except Exception:
                         pass
                     finally:
                         st.session_state["clicked_cell"] = ""
-                    st.experimental_rerun()
+                        st.rerun()
 
                 if st.button("Generuj"):
                     start_val = st.session_state.get("start_input", "")
@@ -448,7 +449,7 @@ def main() -> None:
                             st.session_state["start"] = (sr, sc)
                             st.session_state["end"] = (er, ec)
                             st.session_state["show_solution"] = False
-                            st.experimental_rerun()
+                            st.rerun()
             if st.session_state.get("maze_svg"):
                 if st.button("rozwiązanie"):
                     st.session_state["show_solution"] = not st.session_state.get(

--- a/main.py
+++ b/main.py
@@ -33,6 +33,11 @@ def run_multi_maze() -> None:
     _run_module("multi_maze.py")
 
 
+def run_kontur_maze() -> None:
+    """Launch the kontur-maze program."""
+    _run_module("kontur-maze.py")
+
+
 def show_menu() -> None:
     """Display the start screen with buttons for each activity."""
 
@@ -43,6 +48,9 @@ def show_menu() -> None:
         _rerun()
     if st.button("multi-maze"):
         st.session_state["page"] = "multi-maze"
+        _rerun()
+    if st.button("kontur-maze"):
+        st.session_state["page"] = "kontur-maze"
         _rerun()
     if st.button("test2"):
         st.session_state["page"] = "test2"
@@ -75,6 +83,11 @@ def main() -> None:
             st.session_state["page"] = "menu"
             _rerun()
         run_multi_maze()
+    elif page == "kontur-maze":
+        if st.button("Back"):
+            st.session_state["page"] = "menu"
+            _rerun()
+        run_kontur_maze()
     else:
         st.write(f"{page} clicked")
         if st.button("Back"):


### PR DESCRIPTION
## Summary
- Restore `3dmaze.py` from backup
- Add branch floor using `multi_maze` to create two disconnected mazes and a return elevator detour

## Testing
- `python -m py_compile 3dmaze.py`
- `python - <<'PY'
import importlib
maze = importlib.import_module('3dmaze')
maze.generate_maze(5,5,5)
PY`

------
https://chatgpt.com/codex/tasks/task_e_688bf6e47fc08324995c0000e3c22ff1